### PR TITLE
linear_assignment has been depricated

### DIFF
--- a/src/lib/detectors/base_detector.py
+++ b/src/lib/detectors/base_detector.py
@@ -298,6 +298,7 @@ class BaseDetector(object):
                                 # Change visibility, following the protocal of COCO
                                 pts = np.zeros((8, 3), dtype='int64')
                                 for idx, p in enumerate(pts_ori):
+                                    p = np.squeeze(p)
                                     if p[0] >= ori_width or p[0] < 0 or p[1] < 0 or p[1] >= ori_height:
                                         pts[idx] = [p[0], p[1], 1]  # labeled but not visible
                                     else:

--- a/src/lib/utils/tracker.py
+++ b/src/lib/utils/tracker.py
@@ -3,7 +3,7 @@
 # Full text can be found in LICENSE.md
 
 import numpy as np
-import scipy.optimize.linear_sum_assignment
+from scipy.optimize import linear_sum_assignment
 from numba import jit
 import copy
 from filterpy.kalman import KalmanFilter

--- a/src/lib/utils/tracker.py
+++ b/src/lib/utils/tracker.py
@@ -3,7 +3,7 @@
 # Full text can be found in LICENSE.md
 
 import numpy as np
-from sklearn.utils.linear_assignment_ import linear_assignment
+import scipy.optimize.linear_sum_assignment
 from numba import jit
 import copy
 from filterpy.kalman import KalmanFilter
@@ -154,7 +154,7 @@ class Tracker(object):
         if self.opt.hungarian:
             # item_score = np.array([det['score'] for det in dets], np.float32)  # N
             dist[dist > 1e18] = 1e18
-            matched_indices = linear_assignment(dist)
+            matched_indices = linear_sum_assignment(dist)
         else:
             matched_indices = greedy_assignment(copy.deepcopy(dist))
 

--- a/src/lib/utils/tracker_baseline.py
+++ b/src/lib/utils/tracker_baseline.py
@@ -3,7 +3,7 @@
 # Full text can be found in LICENSE.md
 
 import numpy as np
-from sklearn.utils.linear_assignment_ import linear_assignment
+import scipy.optimize.linear_sum_assignment
 from numba import jit
 import copy
 from filterpy.kalman import KalmanFilter
@@ -150,7 +150,7 @@ class Tracker_baseline(object):
         if self.opt.hungarian:
             item_score = np.array([det['score'] for det in dets], np.float32)  # N
             dist[dist > 1e18] = 1e18
-            matched_indices = linear_assignment(dist)
+            matched_indices = linear_sum_assignment(dist)
         else:
             matched_indices = greedy_assignment(copy.deepcopy(dist))
 

--- a/src/lib/utils/tracker_baseline.py
+++ b/src/lib/utils/tracker_baseline.py
@@ -3,7 +3,7 @@
 # Full text can be found in LICENSE.md
 
 import numpy as np
-import scipy.optimize.linear_sum_assignment
+from scipy.optimize import linear_sum_assignment
 from numba import jit
 import copy
 from filterpy.kalman import KalmanFilter


### PR DESCRIPTION
This was the easiest fix to get it to work. The function linear_sum_assignment from scipy might not be exactly equivalent to linear_assignment from sklearn. Need to validate before deploying. Take a look at [Link](https://stackoverflow.com/a/68847933).